### PR TITLE
Add Jan Matoušek to members

### DIFF
--- a/index.html
+++ b/index.html
@@ -1060,6 +1060,11 @@
         focus:{ cs:"UX · design sprint · uživatelské testování", en:"UX · design sprint · user testing" }
       },
       {
+        name:"Jan Matoušek",
+        href:"https://fit.cvut.cz/cs/fakulta/lide/5249-jan-matousek",
+        focus:{ cs:"Herní enginy · architektura her · únikové hry", en:"Game engines · game architecture · escape rooms" }
+      },
+      {
         name:"Tomáš Nováček",
         href:"members/tn/",
         focus:{ cs:"VR rozhraní · hand-tracking · rendering", en:"VR interfaces · hand tracking · rendering" }


### PR DESCRIPTION
## Co se změnilo

- doplněna karta Jana Matouška do seznamu členů na titulní stránce
- přidáno české i anglické odborné zaměření
- karta odkazuje na jeho oficiální profil FIT ČVUT

## Ověření

- kontrola syntaxe vloženého JavaScriptu
- kontrola českého i anglického textu
- `git diff --check`

Ostatní rozpracované soubory nejsou součástí změny.