### PR TITLE
Fix hero title contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
     }
     body {
       overflow-x: hidden;
+      color: #fff;
     }
     .skip-link {
       position: fixed;
@@ -123,7 +124,7 @@
   </style>
 </head>
 
-<body class="min-h-screen text-neutral-900 dark:text-white bg-gradient-dark dark:bg-gradient-dark">
+<body class="min-h-screen text-white bg-gradient-dark">
   <a class="skip-link" href="#main" data-i18n-key="skipToContent">Přeskočit na obsah</a>
 
   <!-- horní progress pruh -->


### PR DESCRIPTION
## Co se změnilo

- základní barva textu na trvale tmavé titulní stránce je nyní vždy bílá
- odstraněna závislost hlavního nadpisu na systémovém světlém/tmavém režimu
- přidána CSS pojistka pro čitelnost před načtením Tailwind CDN

## Příčina

Výchozí text byl tmavý a bílá barva byla nastavena pouze přes variantu `dark:`. Na zařízení ve světlém systémovém režimu proto hlavní nadpis splýval s tmavým pozadím.

## Ověření

- mobilní viewport 390 × 844
- emulovaný světlý i tmavý systémový režim
- výsledná barva těla i nadpisu v obou režimech `rgb(255, 255, 255)`
- `git diff --check`

Ostatní rozpracované soubory nejsou součástí změny.