### PR TITLE
Add Vivid Dreams and After The Rain to student showcase

### DIFF
--- a/index.html
+++ b/index.html
@@ -700,6 +700,25 @@
     ];
 
     const SHOWCASE = [
+      { id:"sc-vivid-dreams",
+        title:{cs:"Vivid Dreams",en:"Vivid Dreams"},
+        blurb:{
+          cs:"Přepracování a dokončení 2D RPG hry v Unity s procedurálně generovanými úrovněmi.",
+          en:"Reworking and finalising a 2D RPG in Unity with procedurally generated levels."
+        },
+        img:"https://img.itch.zone/aW1nLzI3MDMzNDgzLnBuZw==/508x254%23mb/Wns9WI.png",
+        href:"https://dspace.cvut.cz/entities/publication/7de0ac56-3955-4b13-a48d-497bb2eddfda",
+        tags:["thesis","games","procedural","unity","2026"] },
+      { id:"sc-after-the-rain",
+        title:{cs:"After The Rain",en:"After The Rain"},
+        blurb:{
+          cs:"Narativní puzzle adventura z GameJamu FIT 2026: malý houbový hrdina hledá cestu k záchraně svého úlu.",
+          en:"A narrative puzzle adventure from FIT GameJam 2026: a tiny mushroom hero tries to save its hive."
+        },
+        img:"https://img.itch.zone/aW1nLzI2NTUyODMwLnBuZw==/original/%2BBR%2FGe.png",
+        href:"https://finishx.itch.io/after-the-rain",
+        tags:["gamejam","games","narrative","2026"] },
+
       { id:"sc-wood-texture-generation",
         title:{cs:"Generování dřevěné textury",en:"Wood texture generation"},
         blurb:{


### PR DESCRIPTION
Veřejná homepage: přidány pouze dvě karty do sekce Studentská tvorba — Vivid Dreams a After The Rain. Karty mají českou i anglickou lokalizaci a používají obrázky z oficiálních itch.io stránek. Capitanian ani jiné lokální rozpracované změny nejsou součástí tohoto PR.