### PR TITLE
Polish homepage tags and card alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,9 @@
 
     /* Micro-motion hover for cards */
     .card {
+      display: flex;
+      height: 100%;
+      flex-direction: column;
       transition: transform 300ms cubic-bezier(.2,.8,.2,1), box-shadow 300ms ease;
       box-shadow: 0 10px 30px rgba(0,0,0,0.15);
     }
@@ -59,6 +62,60 @@
     }
     .card:hover .thumb {
       transform: scale(1.08);
+    }
+    .card-body {
+      display: flex;
+      min-width: 0;
+      flex: 1;
+      flex-direction: column;
+    }
+    .card-title-row {
+      align-items: flex-start;
+      gap: .75rem;
+    }
+    .card-kind {
+      flex: 0 0 auto;
+      border: 1px solid rgba(255,255,255,.1);
+      border-radius: 9999px;
+      padding: .2rem .5rem;
+      background: rgba(255,255,255,.035);
+      line-height: 1;
+    }
+    .card-tags {
+      display: flex;
+      min-height: 1.55rem;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: .375rem;
+      margin-top: auto;
+      padding-top: 1rem;
+    }
+    .card-tag {
+      display: inline-flex;
+      align-items: center;
+      min-height: 1.45rem;
+      white-space: nowrap;
+      border: 1px solid rgba(82,82,91,.8);
+      border-radius: 9999px;
+      padding: .1rem .5rem;
+      color: rgb(212 212 216);
+      font-size: .7rem;
+      line-height: 1.1;
+    }
+    .card-tag-more {
+      border-color: rgba(34,211,238,.3);
+      color: rgb(165 243 252);
+      background: rgba(34,211,238,.08);
+    }
+    .filter-tags {
+      max-height: 14rem;
+      align-content: flex-start;
+      overflow-y: auto;
+      overscroll-behavior: contain;
+      scrollbar-color: rgba(103,232,249,.35) transparent;
+    }
+    .filter-tags .filter-label {
+      flex-basis: 100%;
     }
 
     /* Courses */
@@ -116,6 +173,7 @@
       }
       .quick-nav-track::-webkit-scrollbar { display: none; }
       .quick-nav-track .pill { flex: 0 0 auto; }
+      .filter-tags { max-height: 12rem; }
     }
 
     /* Tooltip šipka pro skupinový seznam vyučujících */
@@ -396,7 +454,7 @@
                class="px-3 py-2 rounded-md border border-white/10 bg-black/40 text-white placeholder:text-neutral-500 w-full"/>
       </div>
 
-      <div id="tags" class="mt-3 flex flex-wrap items-center gap-2"></div>
+      <div id="tags" class="filter-tags mt-4 flex flex-wrap items-center gap-2 pr-1"></div>
     </div>
   </div>
 
@@ -1355,7 +1413,7 @@
 
     function chip(text){
       const s=document.createElement('span');
-      s.className="rounded-md px-2 py-0.5 text-[10px] font-medium bg-white/5 text-neutral-200 ring-1 ring-white/10";
+      s.className="whitespace-nowrap rounded-md px-2 py-0.5 text-[10px] font-medium bg-white/5 text-neutral-200 ring-1 ring-white/10";
       s.textContent=text;
       return s;
     }
@@ -1390,7 +1448,7 @@
       body.appendChild(p);
 
       const meta=document.createElement('div');
-      meta.className="mt-2 flex items-center gap-3";
+      meta.className="mt-3 flex flex-wrap items-center gap-2";
       body.appendChild(meta);
 
       if(Array.isArray(c.teachers) && c.teachers.length){
@@ -1398,7 +1456,7 @@
       }
 
       const tagbox=document.createElement('div');
-      tagbox.className="ml-auto flex flex-wrap gap-2";
+      tagbox.className="flex flex-wrap gap-1.5 sm:ml-auto";
       (c.tags||[]).forEach(tag=>tagbox.appendChild(chip(getLocalized(tag))));
       meta.appendChild(tagbox);
 
@@ -1481,7 +1539,7 @@
     function card(item, kind){
       const a = create(
         "a",
-        "card group relative rounded-2xl overflow-hidden border border-white/10 bg-gradient-to-b from-neutral-900 to-black block",
+        "card group relative h-full overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-b from-neutral-900 to-black",
         ""
       );
       setLinkBehavior(a, item.href || "#");
@@ -1521,16 +1579,16 @@
 
       a.appendChild(imgBox);
 
-      const body = create("div","p-4","");
+      const body = create("div","card-body p-4","");
       const headerRow = document.createElement("div");
-      headerRow.className = "flex items-center justify-between";
+      headerRow.className = "card-title-row flex justify-between";
 
       const h3 = document.createElement("h3");
-      h3.className = "text-lg font-semibold text-neutral-100";
+      h3.className = "min-w-0 flex-1 text-lg font-semibold leading-snug text-neutral-100";
       h3.textContent = getLocalized(item.title);
 
       const spanKind = document.createElement("span");
-      spanKind.className = "text-neutral-400 text-xs uppercase tracking-wide";
+      spanKind.className = "card-kind text-[10px] uppercase tracking-wide text-neutral-400";
       const kindLabels = {
         event:{ cs:"událost", en:"event" },
         research:{ cs:"výzkum", en:"research" },
@@ -1543,21 +1601,28 @@
       body.appendChild(headerRow);
 
       const p = document.createElement("p");
-      p.className = "mt-1 text-neutral-300/90 text-sm leading-relaxed";
+      p.className = "mt-2 text-sm leading-relaxed text-neutral-300/90";
       p.textContent = getLocalized(item.blurb);
       body.appendChild(p);
 
       if((item.tags || []).length){
-        const tg = create("div","mt-3 flex flex-wrap gap-2","");
-        (item.tags || []).forEach(t =>
+        const tags = item.tags || [];
+        const tg = create("div","card-tags","");
+        tags.slice(0, 3).forEach(t =>
           tg.appendChild(
             create(
               "span",
-              "text-xs rounded-full border px-2 py-0.5 text-neutral-300 border-neutral-700/80",
+              "card-tag",
               "#" + t
             )
           )
         );
+        if(tags.length > 3){
+          const moreTags = create("span", "card-tag card-tag-more", "+" + (tags.length - 3));
+          moreTags.title = tags.slice(3).map(t => "#" + t).join(", ");
+          moreTags.setAttribute("aria-label", tags.slice(3).join(", "));
+          tg.appendChild(moreTags);
+        }
         body.appendChild(tg);
       }
 
@@ -1648,12 +1713,12 @@
     function renderTags(){
       const T = $("#tags");
       if(!T) return;
-      T.innerHTML = `<span class="text-xs text-neutral-400">${t("filterTagsLabel")}</span>`;
+      T.innerHTML = `<span class="filter-label text-xs font-semibold uppercase tracking-wide text-neutral-400">${t("filterTagsLabel")}</span>`;
 
       allTags.forEach(tagText=>{
         const b = create(
           "button",
-          "px-3 py-1 rounded-full border text-sm border-neutral-700 text-neutral-300 hover:border-neutral-500",
+          "inline-flex min-h-8 items-center justify-center whitespace-nowrap rounded-full border border-neutral-700 px-3 py-1 text-sm text-neutral-300 transition-colors hover:border-neutral-500",
           ""
         );
         b.textContent = tagText;
@@ -1661,15 +1726,18 @@
           activeTags.has(tagText) ? activeTags.delete(tagText) : activeTags.add(tagText);
           b.classList.toggle("bg-cyan-500/20");
           b.classList.toggle("border-cyan-400");
+          b.classList.toggle("text-cyan-100");
+          b.setAttribute("aria-pressed", String(activeTags.has(tagText)));
           applyFilter();
         };
+        b.setAttribute("aria-pressed", "false");
         T.appendChild(b);
       });
 
       if(allTags.length){
         const reset = create(
           "button",
-          "ml-2 text-xs text-cyan-300 hover:text-cyan-200",
+          "w-full pt-1 text-left text-xs text-cyan-300 hover:text-cyan-200",
           t("filterReset")
         );
         reset.onclick = () => {


### PR DESCRIPTION
## Summary
- align card titles, type labels and bottom metadata consistently
- show at most three primary tags plus a compact `+N` indicator
- keep every tag available in the filter drawer
- make the filter tag area bounded and independently scrollable on mobile
- improve course metadata wrapping and active filter accessibility

## Validation
- local validator passed: 25 HTML, 5 JS and 7 CSS files
- `git diff --check` passed
- browser QA at 390x844 and 1440x1000
- all tested card tag groups stay on one row in CZ and EN
- filter interaction and `aria-pressed` state verified
- remote compare contains exactly one modified file: `index.html`